### PR TITLE
feat: add takt installation and symlink setup

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,7 +1,7 @@
 [tools]
 aqua = "latest"
 gcloud = "latest"
-aws = "latest"
+awscli = "latest"
 jq = "latest"
 yq = "latest"
 uv = "latest"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,0 +1,8 @@
+[tools]
+aqua = "latest"
+gcloud = "latest"
+aws = "latest"
+jq = "latest"
+yq = "latest"
+uv = "latest"
+"npm:takt" = "latest"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,12 +34,7 @@ curl -o ~/.zsh/git-prompt.zsh https://raw.githubusercontent.com/woefe/zsh-git-pr
 # 	touch $(pwd)/zsh-completions-chmod-done.tmp
 # fi
 
-mise use -g gcloud@latest
-mise use -g aws@latest
-mise use -g jq@latest
-mise use -g yq@latest
-mise use -g uv@latest
-mise use -g npm:takt@latest
+mise install
 
 claude mcp add serena -s user -- mise x -- uvx --from "git+https://github.com/oraios/serena" serena start-mcp-server --enable-web-dashboard false --context ide-assistant
 claude mcp add codex codex mcp-server

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,6 +22,7 @@ brew install claude
 brew install chatgpt
 brew install codex
 brew install dbeaver-community
+brew install google-japanese-ime
 
 if [ ! -e ~/.zsh ]; then
 	mkdir ~/.zsh
@@ -38,6 +39,7 @@ mise use -g aws@latest
 mise use -g jq@latest
 mise use -g yq@latest
 mise use -g uv@latest
+mise use -g npm:takt@latest
 
 claude mcp add serena -s user -- mise x -- uvx --from "git+https://github.com/oraios/serena" serena start-mcp-server --enable-web-dashboard false --context ide-assistant
 claude mcp add codex codex mcp-server

--- a/scripts/link.sh
+++ b/scripts/link.sh
@@ -19,8 +19,10 @@ ln -s $(pwd)/.vimrc ~/.vimrc
 
 mkdir -p ~/.agents
 mkdir -p ~/.claude
+mkdir -p ~/.config/mise
 ln -s $(pwd)/.agents/skills ~/.agents
 ln -s $(pwd)/.agents/skills ~/.claude
 ln -s $(pwd)/.claude/settings.json ~/.claude/settings.json
 ln -s $(pwd)/.claude/statusline.js ~/.claude/statusline.js && chmod +x ~/.claude/statusline.js
 ln -s $(pwd)/.takt ~/.takt
+ln -s $(pwd)/.config/mise/config.toml ~/.config/mise/config.toml

--- a/scripts/link.sh
+++ b/scripts/link.sh
@@ -23,3 +23,4 @@ ln -s $(pwd)/.agents/skills ~/.agents
 ln -s $(pwd)/.agents/skills ~/.claude
 ln -s $(pwd)/.claude/settings.json ~/.claude/settings.json
 ln -s $(pwd)/.claude/statusline.js ~/.claude/statusline.js && chmod +x ~/.claude/statusline.js
+ln -s $(pwd)/.takt ~/.takt


### PR DESCRIPTION
## Summary
- Add `google-japanese-ime` and `takt` (via mise) to install script
- Add `.takt` symlink to link script for takt configuration sharing

## Test plan
- [ ] Run `scripts/install.sh` and verify takt and google-japanese-ime are installed
- [ ] Run `scripts/link.sh` and verify `.takt` symlink is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)